### PR TITLE
v0.0.9

### DIFF
--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -343,20 +343,6 @@ paths:
       description: list OrderProduct entities
       security:
         - API Key: []
-    post:
-      summary: ''
-      operationId: post-orders-order_id-products
-      responses:
-        '201':
-          description: Created
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - API Key: []
   '/retail/orders/{order_id}/order_products/{order_product_id}':
     parameters:
       - schema:


### PR DESCRIPTION
v0.0.8 -> v0.0.9 の更新です。  
(今日MTG中にマージしていただいたPRでバージョン番号インクリメントしていて、そのあとdevelopブランチを作ったのでこのPRだと0.0.9へ変更するchangesが入ってません)

- `POST /retail/orders`
  - https://github.com/minedia/tanomimaster-openapi/pull/2
  - https://github.com/minedia/tanomimaster-openapi/pull/5
- `POST /retail/products/check_code`
  - https://github.com/minedia/tanomimaster-openapi/pull/4
- `PATCH /retail/orders/:order_id/order_products/:id`
  - https://github.com/minedia/tanomimaster-openapi/pull/3

本日のMTGで決定した内容を反映しました。