### PR TITLE
APIで注文作成する場合の注文番号の許容文字を数字10桁(以上)とする

### DIFF
--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.0.12
+  version: 0.0.13
   title: REST API for makers
   description: Main file of Maker REST API.
   license:
@@ -1035,12 +1035,12 @@ paths:
                       ordered_at: '2020/03/03 12:43:36'
                       makers:
                         - maker_code: matsukura
-                          shipping_postcode: "338-0824"
-                          shipping_preferecture_code: "11"
-                          shipping_city: "さいたま市桜区"
-                          shipping_street_address: "上大久保８８８－５"
+                          shipping_postcode: 338-0824
+                          shipping_preferecture_code: '11'
+                          shipping_city: さいたま市桜区
+                          shipping_street_address: 上大久保８８８－５
                           shipping_building: null
-                          shipping_office_name: "日本瓦斯株式会社　浦和営業所"
+                          shipping_office_name: 日本瓦斯株式会社　浦和営業所
                           shipping_tel: 048-854-1910
                           retail_user_code: matsukura-sales
                           retail_sales_office_code: '000'
@@ -1557,7 +1557,8 @@ components:
       properties:
         code:
           type: string
-          description: ''
+          pattern: '^[0-9]{10,}$'
+          description: 注文番号
         makers:
           type: array
           minItems: 1


### PR DESCRIPTION
refs https://github.com/minedia/tanomimaster-www/issues/690

注文番号の許容文字を数字10桁(以上)とする