### PR TITLE
HTTP header is required to be lowercase

### DIFF
--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -95,23 +95,23 @@ paths:
         '200':
           description: A paged array of products
           headers:
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -225,23 +225,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/OrderWithDescendant'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -389,23 +389,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/OrderProduct'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -676,23 +676,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/Maker'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -1030,23 +1030,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/RetailBranch'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -1099,23 +1099,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/RetailSalesOffice'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -1347,23 +1347,23 @@ paths:
         '200':
           description: OK
           headers:
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -1712,24 +1712,24 @@ paths:
                 items:
                   $ref: '#/components/schemas/Category'
           headers:
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
         default:
@@ -1816,23 +1816,23 @@ paths:
                 items:
                   $ref: '#/components/schemas/Category'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -1907,23 +1907,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/DeliveryCompany'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2005,23 +2005,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/GasType'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2104,23 +2104,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/Maker'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2289,23 +2289,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/MakerSalesOffice'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2407,23 +2407,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/Retail'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2592,23 +2592,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/RetailSalesOffice'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -2787,23 +2787,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/Product'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -3089,23 +3089,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/OrdersMakerWithDescendant'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true
@@ -3193,23 +3193,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/OrderProduct'
           headers:
-            X-Page:
+            x-page:
               schema:
                 type: integer
-            X-Per-Page:
+            x-per-page:
               schema:
                 type: integer
-            X-Prev-Page:
+            x-prev-page:
               schema:
                 type: integer
                 nullable: true
-            X-Total:
+            x-total:
               schema:
                 type: integer
-            X-Total-Pages:
+            x-total-pages:
               schema:
                 type: integer
-            X-Next-Page:
+            x-next-page:
               schema:
                 type: integer
                 nullable: true


### PR DESCRIPTION
Adjust for HTTP/2 when upgrading Ruby on Rails 7.1