### PR TITLE
Automation用の商品一覧取得APIを追加

### DIFF
--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -188,6 +188,97 @@ paths:
                 $ref: '#/components/schemas/Error'
       security:
         - ApiKeyAuth: []
+  /retail/products/automation:
+    get:
+      summary: 販売中商品の一覧を取得（卸用、価格情報付き）
+      operationId: getProductsForAutomation
+      description: 販売中の商品一覧を、メーカ希望小売価格(price_amount)付きで返却
+      tags:
+        - Retail
+      parameters:
+        - name: limit
+          in: query
+          description: 項目数
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            default: 25
+            maximum: 100
+        - schema:
+            type: integer
+            minimum: 1
+            default: 1
+          name: page
+          in: query
+          required: false
+          description: ページ数
+          example: 2
+        - schema:
+            type: string
+          in: query
+          name: maker_code
+          description: ''
+        - schema:
+            type: string
+          in: query
+          name: product_code
+        - name: updated_at_from
+          in: query
+          description: 更新日FROM
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: updated_at_to
+          in: query
+          description: 更新日TO
+          required: false
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: A paged array of products
+          headers:
+            x-total-pages:
+              schema:
+                type: integer
+            x-total:
+              schema:
+                type: integer
+            x-prev-page:
+              schema:
+                type: integer
+                nullable: true
+            x-per-page:
+              schema:
+                type: integer
+            x-page:
+              schema:
+                type: integer
+            x-next-page:
+              schema:
+                type: integer
+                nullable: true
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProductForRetailAutomation'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - ApiKeyAuth: []
   '/retail/products/{product_id}':
     get:
       summary: 販売中商品を取得
@@ -3789,6 +3880,25 @@ components:
         - id
         - name
         - category_id
+    ProductForRetailAutomation:
+      title: ProductForRetailAutomation
+      type: object
+      xml:
+        name: ProductForRetailAutomation
+      x-tags:
+        - product
+      description: A single product with price_amount for wholesale automation.
+      allOf:
+        - $ref: '#/components/schemas/ProductForRetail'
+        - type: object
+          properties:
+            price_amount:
+              type: integer
+              nullable: true
+              description: メーカ希望小売価格(税抜)
+              example: 10000
+          required:
+            - price_amount
     ProductForKumo:
       title: Product for kumo
       type: object

--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -3888,15 +3888,68 @@ components:
       x-tags:
         - product
       description: A single product with price_amount for wholesale automation.
-      allOf:
-        - $ref: '#/components/schemas/ProductForRetail'
-        - type: object
-          properties:
-            price_amount:
-              type: integer
-              nullable: true
-              description: メーカ希望小売価格(税抜)
-              example: 10000
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+          description: '商品ID'
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2022-06-06T18:32:35.956+09:00'
+        estimated_delivery_duration:
+          type: integer
+          nullable: true
+          description: '目安納期日数'
+          example: 3
+        use_gas_type_master:
+          type: boolean
+          nullable: true
+          description: 'ガス種の選択を必要とするか'
+          example: true
+        maker_id:
+          type: integer
+          description: 'メーカID'
+          deprecated: true
+          example: 1
+        internal_code:
+          type: string
+          nullable: true
+          description: 'メーカ内部コード'
+          example: '000-111'
+        name:
+          type: string
+          description: '商品名'
+          example: 商品A
+        category_id:
+          type: integer
+          description: カテゴリID
+          example: 1
+        maker_code:
+          type: string
+          description: メーカコード
+          example: '0001'
+        price_amount:
+          type: integer
+          nullable: true
+          description: メーカ希望小売価格(税抜)
+          example: 10000
+        created_at:
+          type: string
+          format: date-time
+          description: 'レコード作成日時'
+          example: '2022-06-06T18:32:35.956+09:00'
+        updated_at:
+          type: string
+          format: date-time
+          description: 'レコード更新日時'
+          example: '2022-06-06T18:32:35.956+09:00'
+      required:
+        - id
+        - name
+        - category_id
     ProductForKumo:
       title: Product for kumo
       type: object

--- a/tanomimaster.yml
+++ b/tanomimaster.yml
@@ -3897,8 +3897,6 @@ components:
               nullable: true
               description: メーカ希望小売価格(税抜)
               example: 10000
-          required:
-            - price_amount
     ProductForKumo:
       title: Product for kumo
       type: object


### PR DESCRIPTION
issue:https://github.com/tanomimaster/tanomimaster-www/issues/2464 

## 対応内容
販売中の商品一覧取得（既存＋メーカー小売価格）のエンドポイントを追加